### PR TITLE
Security updates to the publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   build:
-    uses: open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    uses: >
+      open-edge-platform/orch-ci/.github/workflows/
+      publish-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
     secrets:
       SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
       DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,8 +5,16 @@
 name: Publish Documentation
 on:   # yamllint disable-line rule:truthy
   workflow_dispatch:
+
+permissions:
+  contents: read          # needed for actions/checkout
+  pull-requests: read     # needed for gh pr list
+  issues: write           # needed to post PR comment
+
 jobs:
   build:
-    uses: >-
-      open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@main
-    secrets: inherit
+    uses: open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,9 +13,8 @@ permissions:
 
 jobs:
   build:
-    uses: >
-      open-edge-platform/orch-ci/.github/workflows/
-      publish-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    uses: >-
+      open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
     secrets:
       SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
       DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
# PR Description

This pull request updates the `.github/workflows/publish-docs.yml` file to enhance security and functionality. The most important changes include adding permissions for GitHub Actions and specifying secrets explicitly.

### Workflow configuration updates:

* Added `permissions` block to define specific access levels for `contents`, `pull-requests`, and `issues` to improve security and ensure the workflow has only the necessary permissions.

* Updated the `uses` reference for the `build` job to point to a specific commit (`734970a73e3d6e8d7cd160e2cad6366770f52403`) instead of `main`, ensuring the workflow's stability and reproducibility.

* Replaced `secrets: inherit` with explicit secrets to provide more granular control over sensitive data.

## Checklist

- [x] Tests passed
- [ ] Documentation updated
