### PR TITLE
Add note about the deploy_tag in the onprem documentation

### DIFF
--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -206,8 +206,9 @@ Build repo archive and installer packages and move them to default directories:
 
 Ensure that the ``TF_VAR_deploy_tag`` is set to the correct version that matches the version of Debian\* packages.
 Due to Debian versioning, if you are building from a tagged version branch (e.g., v3.0.0), the ``mage build:all`` command will remove the v prefix so you may need to manually export ``TF_VAR_deploy_tag``.
-
-If the ``TF_VAR_deploy_tag`` is set, because of the Terraform's precendence rules, the `deploy_tag` must not be set in the ``terraform/orchestrator/terraform.tfvars`` file.
+If ``TF_VAR_deploy_tag`` is set, ensure that ``deploy_tag`` is not defined in 
+the ``terraform/orchestrator/terraform.tfvars`` file due to Terraform's 
+precedence rules.
 
 Edit ``terraform/orchestrator/terraform.tfvars`` to use locally built
 artifacts:

--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -27,12 +27,11 @@ Your development machine must have the following software installed:
   - Download the appropriate asdf binary for your operating system/architecture
     combo from the `GitHub releases page
     <https://github.com/asdf-vm/asdf/releases>`_. Ensure to place it in a
-    directory on your $PATH.
-
-   - Prepend ``$ASDF_DATA_DIR/shims`` to your ``$PATH`` environment variable.
+    directory on your ``$PATH``. For example, you can prepend 
+    ``$ASDF_DATA_DIR/shims`` to your ``$PATH`` environment variable:
 
    .. code-block:: bash
-      
+
       export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 - Docker\* software

--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -207,6 +207,8 @@ Build repo archive and installer packages and move them to default directories:
 Ensure that the ``TF_VAR_deploy_tag`` is set to the correct version that matches the version of Debian\* packages.
 Due to Debian versioning, if you are building from a tagged version branch (e.g., v3.0.0), the ``mage build:all`` command will remove the v prefix so you may need to manually export ``TF_VAR_deploy_tag``.
 
+If the ``TF_VAR_deploy_tag`` is set, because of the Terraform's precendence rules, the `deploy_tag` must not be set in the ``terraform/orchestrator/terraform.tfvars`` file.
+
 Edit ``terraform/orchestrator/terraform.tfvars`` to use locally built
 artifacts:
 


### PR DESCRIPTION
# PR Description

If the deploy_tag is set in the terraform.tfvars file, because of terraforms precedence rule, it will overwrite the value set using the environment variable TF_VAR_deploy_tag. The purpose of this change is to notify the user that if that value is set, the install will fail.

## Changes

Update onprem doc.

## Additional Information

N/A

## Checklist

- [x] Tests passed
- [x] Documentation updated
