### PR TITLE
Fix minor on-prem installation documentation issues

### DIFF
--- a/docs/deployment_guide/on_prem_deployment/index.rst
+++ b/docs/deployment_guide/on_prem_deployment/index.rst
@@ -6,7 +6,6 @@ Edge Orchestrator On-Premises Installation Guide
 - :doc:`/deployment_guide/on_prem_deployment/on_prem_get_started/system_requirements_on_prem_orch`
 - :doc:`/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_certs`
 - :doc:`/shared/shared_gs_preinstall`
-- :doc:`/shared/shared_traefik_rate_limit`
 - :doc:`/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_install`
 - :doc:`/shared/shared_gs_iam`
 - :doc:`/shared/shared_mt_overview`

--- a/docs/deployment_guide/on_prem_deployment/on_prem_get_started/index.rst
+++ b/docs/deployment_guide/on_prem_deployment/on_prem_get_started/index.rst
@@ -301,7 +301,6 @@ When deploying Edge Orchestrator with Squid proxy, you will need an additional f
    system_requirements_on_prem_orch
    on_prem_certs
    ../../../shared/shared_gs_preinstall
-   ../../../shared/shared_traefik_rate_limit
    on_prem_install
    ../../../shared/shared_gs_iam
    ../../../shared/shared_mt_overview

--- a/docs/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_certs.rst
+++ b/docs/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_certs.rst
@@ -68,4 +68,4 @@ Orchestrator.
 
 Using a Self-Signed certificate requires the certificate to be manually added to the trust stores of all clients (e.g., CLI tools, browsers, etc) that want to access the Edge Orchestrator. If a client does not trust the Self-Signed certificate, the client's browser will display an insecure warning when attempting to access the Edge Orchestrator, up to refusing to connect to the Edge Orchestrator.
 
-See :doc:`/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_certs` for information on how to generate a TLS certificate.
+See :doc:`/deployment_guide/on_prem_deployment/on_prem_how_to/on_prem_certificates` for information on how to generate a TLS certificate.

--- a/docs/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_install.rst
+++ b/docs/deployment_guide/on_prem_deployment/on_prem_get_started/on_prem_install.rst
@@ -234,9 +234,15 @@ The installer script prompts for configuration input during installation.
 
 #. The installer prompts you to enter the IP addresses used by the
    Load Balancer for Argo CD UI, Traefik application proxy, and NGINX web server as follows.
-   These IPs must be in the same subnet (for example, `10.0.0.1/24`) of the
-   Edge Orchestrator Node, see
-   `Edge Orchestrator Network Topology <./index.html#edge-orchestrator-network-topology>`__.
+   There are strict requirements on these IP addresses:
+   - All three IP addresses must be in the same subnet (for example, `10.0.0.1/24`) of the
+     Edge Orchestrator Node.
+   - IP addresses must be unique - you cannot use the same IP address for all three endpoints.
+     The installation will fail, if any IP address is duplicated.
+   - These are "Virtual IPs" - they don't need to be assigned to any hardware network interface,
+     but they should be reserved within the local subnet. Make sure your DHCP server doesn't assign conflicting IP addresses.
+
+   See `Edge Orchestrator Network Topology <./on_prem_prereq.html#edge-orchestrator-network-topology>`__ for more details about network configurations.
 
    For an example of the topology.
 
@@ -251,9 +257,9 @@ The installer script prompts for configuration input during installation.
       Enter Argo IP:
       [xx.xx.xx.xx]
       Enter Traefik IP:
-      [xx.xx.xx.xx]
+      [yy.yy.yy.yy]
       Enter Nginx IP:
-      [xx.xx.xx.xx]
+      [zz.zz.zz.zz]
 
 Configure Custom Settings
 ++++++++++++++++++++++++++++
@@ -372,6 +378,15 @@ Configure Custom Settings
 
    This configuration applies for every organization and project by default when they are created, but you can edit the nZTP configuration for each project at a later time.
    To learn more about the nZTP feature, see the :doc:`/user_guide/concepts/nztp` section in the *User Guide*.
+
+#. You can configure custom Traefik Rate Limit. See :doc:`/shared/shared_traefik_rate_limit`.
+
+   Configure the Traefik\* rate limit in ``[path_to_untarred_repo]/orch-configs/profiles/default-traefik-rate-limit.yaml``
+   and add the profile in the ``[path_to_untarred_repo]/orch-configs/clusters/onprem.yaml`` file:
+
+   .. code-block:: shell
+
+       +    - profiles/default-traefik-rate-limit.yaml
 
 
 Disable SRE (Optional)
@@ -666,8 +681,8 @@ file:
 
    address=/loca.<on.prem.domain.name>/<loca-external-ip>
 
-Add Exceptions to the Browser Certificate
-+++++++++++++++++++++++++++++++++++++++++
+Add Exceptions to the Browser or Import Self-Signed Certificate (Optional)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Add exceptions to your browser for the following Edge Orchestrator domains,
 replacing ``CLUSTER_FQDN`` with domain that you used during installation when
@@ -678,6 +693,14 @@ using self-signed certificates:
 * \https://argocd.CLUSTER_FQDN
 * \https://vnc.CLUSTER_FQDN
 * \https://CLUSTER_FQDN
+
+You can also retrieve self-signed certificate from the cluster:
+
+.. code-block:: shell
+
+   kubectl get secret -n orch-gateway tls-orch -o jsonpath='{.data.ca\.crt}' | base64 --decode > orch.crt
+
+Copy the ``orch.crt`` file to your local machine and import it to your system trust store.
 
 Add Exceptions to the Browser Certificate for LOC-A (Optional)
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/shared/shared_gs_iam.rst
+++ b/docs/shared/shared_gs_iam.rst
@@ -42,7 +42,7 @@ Change the IdP Admin password
 2. Choose **Administration Console**. You may be redirected to this page by
    default.
 
-4. Next to user account icon at top left, click the ``admin`` username and
+4. Next to user account icon at top right, click the ``admin`` username and
    select ``Manage account``.
 
 5. Navigate to the **Account Security** tab and click on ``Signing in``, and in

--- a/docs/shared/shared_mt_overview.rst
+++ b/docs/shared/shared_mt_overview.rst
@@ -25,8 +25,6 @@ An organization is the top-level tenant construct, which provides:
 * Isolation of organization-wide observability data, which are the logs and
   metrics.
 
-* Licensing of the Edge Node software.
-
 Projects
 ~~~~~~~~
 


### PR DESCRIPTION
# PR Description

Clarify the on-prem installation guide.

## Changes

- Moved Traefik Rate Limit configuration site from the main menu to customization steps in the on-prem installation guide. Previously, the Traefik Rate Limit configuration site was randomly placed.
- Clarified IP address configuration for Traefil/Argo/Nginx endpoints
- Add steps to retrieve self-signed certificate and import it to system trust store
- removed leftover about EN licensing 

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
