### PR TITLE
Test version dropdown menu support.

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read          # needed for actions/checkout
       pull-requests: read     # needed for gh pr list
       issues: write           # needed to post PR comment
-    uses: open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@2f1b44c87e3c1f8f239d5297ef9e7f3577e40241  # yamllint disable-line rule:line-length
+    uses: open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@jmo/Support-version-switcher  # yamllint disable-line rule:line-length
     with:
       simple_mode: false
     secrets:


### PR DESCRIPTION
# PR Description

Test the new version dropdown menu support of `orch-ci` workflow [publish-documentation.yml](https://github.com/open-edge-platform/orch-ci/pull/141)

## Changes

Temporarily switch to using the [jmo/Support-version-switcher](https://github.com/open-edge-platform/orch-ci/tree/jmo/Support-version-switcher) branch of `orch-ci` to test version dropdown menu support.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
