### PR TITLE
Update troubleshooting page when deploying on-prem

### DIFF
--- a/docs/deployment_guide/on_prem_deployment/on_prem_troubleshooting/index.rst
+++ b/docs/deployment_guide/on_prem_deployment/on_prem_troubleshooting/index.rst
@@ -13,6 +13,7 @@ deployment operations during the installation process. If an operation fails, yo
 - :doc:`/shared/shared_ts_dkam_fail_state`
 - :doc:`/shared/shared_ts_rs_token`
 - :doc:`/shared/shared_ts_sriov_webhook`
+- :doc:`/shared/shared_on_prem_rs_proxy`
 
 .. toctree::
    :hidden:
@@ -22,3 +23,4 @@ deployment operations during the installation process. If an operation fails, yo
    ../../../shared/shared_ts_dkam_fail_state
    ../../../shared/shared_ts_rs_token
    ../../../shared/shared_ts_sriov_webhook
+   ../../../shared/shared_on_prem_rs_proxy

--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -1,3 +1,5 @@
+.. _set_up_dev_env:
+
 Set Up Developer Environment
 ============================
 

--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -1,4 +1,4 @@
-.. _set_up_dev_env:
+.. _set_up_dev_environment:
 
 Set Up Developer Environment
 ============================

--- a/docs/shared/shared_on_prem_rs_proxy
+++ b/docs/shared/shared_on_prem_rs_proxy
@@ -1,0 +1,61 @@
+rs-proxy is not deploying when proxy is set
+===========================================
+
+The recommended way to set the proxy on on-prem is by following the approach described in :ref:`_set_up_dev_env`.
+
+However, it has been observed that in some environments behind a proxy, egress communication may be blocked by the `istio-proxy`. As a result, the `rs-proxy` does not get deployed. To resolve this, follow these steps:
+
+1. For simplicity, assume this is a first-time deployment. Run the command below to uninstall the on-prem orchestrator:
+
+    .. code-block:: shell
+
+       ./uninstall_onprem.sh
+
+2. Run the following command to set up the on-prem orchestrator environment:
+
+    .. code-block:: shell
+
+       source .env
+       unset PROCEED
+
+3. Start the on-prem orchestrator installer:
+
+    .. code-block:: shell
+
+       ./onprem_installer.sh
+
+4. Wait until the installer asks for permission to proceed with the installation. Do not type `y` yet.
+
+    .. code-block:: shell
+
+       Enter 'yes' to confirm that configuration is done in order to progress with installation
+       ('no' will exit the script) !!!
+
+       Ready to proceed with installation? 
+
+5. In a separate terminal window, SSH into the VM running the installer. This document assumes the `onprem` profile is installed. If different, adjust as needed. Open the profile file:
+
+    .. code-block:: shell
+
+       nano repo_archives/tmp/edge-manageability-framework/orch-configs/profiles/profile-onprem.yaml
+
+6. Append the configuration below. Adjust `<proxy_port>` and `<proxy_ip>` according to your environment. Save and close the file.
+
+    .. code-block:: shell
+
+       postCustomTemplateOverwrite:
+         rs-proxy:
+           podAnnotations:
+             reloader.stakater.com/auto: "true"
+             sidecar.istio.io/inject: "true"
+             traffic.sidecar.istio.io/excludeOutboundPorts: "<proxy_port>"
+             traffic.sidecar.istio.io/excludeOutboundIPRanges: <proxy_ip>/32
+
+7. Copy the proxy configuration:
+
+    .. code-block:: shell
+
+       cp proxy_config.yaml repo_archives/tmp/edge-manageability-framework/orch-configs/profiles/proxy-none.yaml
+
+8. Return to the first terminal and type `y` to proceed with the installation.
+

--- a/docs/shared/shared_on_prem_rs_proxy.rst
+++ b/docs/shared/shared_on_prem_rs_proxy.rst
@@ -5,26 +5,26 @@ The recommended way to set the proxy on on-prem is by following the approach des
 
 However, it has been observed that in some environments behind a proxy, egress communication may be blocked by the `istio-proxy`. As a result, the `rs-proxy` does not get deployed. To resolve this, follow these steps:
 
-1. For simplicity, assume this is a first-time deployment. Run the command below to uninstall the on-prem orchestrator:
+#. For simplicity, assume this is a first-time deployment. Run the command below to uninstall the on-prem orchestrator:
 
     .. code-block:: shell
 
        ./uninstall_onprem.sh
 
-2. Run the following command to set up the on-prem orchestrator environment:
+#. Run the following command to set up the on-prem orchestrator environment:
 
     .. code-block:: shell
 
        source .env
        unset PROCEED
 
-3. Start the on-prem orchestrator installer:
+#. Start the on-prem orchestrator installer:
 
     .. code-block:: shell
 
        ./onprem_installer.sh
 
-4. Wait until the installer asks for permission to proceed with the installation. Do not type `y` yet.
+#. Wait until the installer asks for permission to proceed with the installation. Do not type `y` yet.
 
     .. code-block:: shell
 
@@ -33,13 +33,13 @@ However, it has been observed that in some environments behind a proxy, egress c
 
        Ready to proceed with installation? 
 
-5. In a separate terminal window, SSH into the VM running the installer. This document assumes the `onprem` profile is installed. If different, adjust as needed. Open the profile file:
+#. In a separate terminal window, SSH into the VM running the installer. This document assumes the `onprem` profile is installed. If different, adjust as needed. Open the profile file:
 
     .. code-block:: shell
 
        nano repo_archives/tmp/edge-manageability-framework/orch-configs/profiles/profile-onprem.yaml
 
-6. Append the configuration below. Adjust `<proxy_port>` and `<proxy_ip>` according to your environment. Save and close the file.
+#. Append the configuration below. Adjust `<proxy_port>` and `<proxy_ip>` according to your environment. Save and close the file.
 
     .. code-block:: shell
 
@@ -51,11 +51,11 @@ However, it has been observed that in some environments behind a proxy, egress c
              traffic.sidecar.istio.io/excludeOutboundPorts: "<proxy_port>"
              traffic.sidecar.istio.io/excludeOutboundIPRanges: <proxy_ip>/32
 
-7. Copy the proxy configuration:
+#. Copy the proxy configuration:
 
     .. code-block:: shell
 
        cp proxy_config.yaml repo_archives/tmp/edge-manageability-framework/orch-configs/profiles/proxy-none.yaml
 
-8. Return to the first terminal and type `y` to proceed with the installation.
+#. Return to the first terminal and type `y` to proceed with the installation.
 

--- a/docs/shared/shared_on_prem_rs_proxy.rst
+++ b/docs/shared/shared_on_prem_rs_proxy.rst
@@ -1,7 +1,7 @@
 rs-proxy is not deploying when proxy is set
 ===========================================
 
-The recommended way to set the proxy on on-prem is by following the approach described in :ref:`_set_up_dev_env`.
+The recommended way to set the proxy on on-prem is by following the approach described in :ref:`set_up_dev_environment`.
 
 However, it has been observed that in some environments behind a proxy, egress communication may be blocked by the `istio-proxy`. As a result, the `rs-proxy` does not get deployed. To resolve this, follow these steps:
 


### PR DESCRIPTION
# PR Description

This PR updates the troubleshooting page with a workaround in case `rs-proxy` does not deploy when proxy is set.

## Changes



## Additional Information


## Checklist

- [x] Tests passed
- [x] Documentation updated
