### PR TITLE
Removing direct links to docs.openedgeplatform

### DIFF
--- a/docs/developer_guide/infra_manager/arch/day2_flow.rst
+++ b/docs/developer_guide/infra_manager/arch/day2_flow.rst
@@ -51,7 +51,7 @@ Manager, refer to the `Maintenance Manager documentation <https://github.com/ope
 
 An Edge Node update can be scheduled through the Web UI, which creates a dedicated maintenance
 window for the update process. To learn more about scheduling updates for Edge Nodes, see the
-`guide on scheduling maintenance <https://docs.openedgeplatform.intel.com/edge-manage-docs/main/user_guide/additional_howtos/host_schedule_main.html>`_.
+:ref:`guide on scheduling maintenance <user_guide/additional_howtos/host_schedule_main:Schedule Maintenance for Configured and Active Hosts>`.
 
 
 EN Update Flow

--- a/docs/developer_guide/infra_manager/arch/extensibility.rst
+++ b/docs/developer_guide/infra_manager/arch/extensibility.rst
@@ -18,7 +18,7 @@ Layer (DAL) business logic, the next step is to define the REST APIs through
 which users and external components can consume those resources. The REST APIs
 are defined in the Edge Infrastructure Manager `OpenAPI
 <https://www.openapis.org/>`_ specification (see :ref:`API
-documentation <api/edge_infra_manager>`_).
+documentation <api/edge_infra_manager:Edge Infrastructure Manager API>`).
 
 Edge Infrastructure Manager northbound APIs are designed to be declarative: the
 consumer express an Intent that gets translated into a `desired` field in the

--- a/docs/developer_guide/infra_manager/arch/extensibility.rst
+++ b/docs/developer_guide/infra_manager/arch/extensibility.rst
@@ -17,8 +17,8 @@ Once new abstractions have been added to Inventory including the Data Access
 Layer (DAL) business logic, the next step is to define the REST APIs through
 which users and external components can consume those resources. The REST APIs
 are defined in the Edge Infrastructure Manager `OpenAPI
-<https://www.openapis.org/>`_ specification (see `API
-documentation <https://docs.openedgeplatform.intel.com/edge-manage-docs/main/api/edge_infra_manager.html>`_).
+<https://www.openapis.org/>`_ specification (see :ref:`API
+documentation <api/edge_infra_manager>`_).
 
 Edge Infrastructure Manager northbound APIs are designed to be declarative: the
 consumer express an Intent that gets translated into a `desired` field in the

--- a/docs/shared/shared_os_profile.rst
+++ b/docs/shared/shared_os_profile.rst
@@ -162,4 +162,5 @@ You must repackage third-party software in this format if you want to install it
 Edge Infrastructure Manager API
 -------------------------------
 
-.. note:: You can also refer to the :ref:`Edge Infrastructure Manager API documentation <api/edge_infra_manager>`_.
+.. note:: You can also refer to the
+   :ref:`Edge Infrastructure Manager API documentation <api/edge_infra_manager:Edge Infrastructure Manager API>`.

--- a/docs/shared/shared_os_profile.rst
+++ b/docs/shared/shared_os_profile.rst
@@ -162,4 +162,4 @@ You must repackage third-party software in this format if you want to install it
 Edge Infrastructure Manager API
 -------------------------------
 
-.. note:: `You can also refer to the Edge Infrastructure Manager API <https://docs.openedgeplatform.intel.com/edge-manage-docs/main/api/files/edge_infra_manager.html>`__.
+.. note:: You can also refer to the :ref:`Edge Infrastructure Manager API documentation <api/edge_infra_manager>`_.


### PR DESCRIPTION
# PR Description

Removing direct links to docs.openedgeplatform to internal reference to favor linking within tagged versions. 

## Checklist

- [x] Tests passed
- [x] Documentation updated
