### PR TITLE
Revert "Aligning minimum requirements for dev and on-prem"

### DIFF
--- a/docs/developer_guide/set_up_dev_env/index.rst
+++ b/docs/developer_guide/set_up_dev_env/index.rst
@@ -8,14 +8,14 @@ System Requirements
 
 Your development machine must meet the following minimum requirements:
 
-- Operating System: Ubuntu\* 24.04 Server
+- Operating System: Ubuntu\* 22.04 Server
 
-- Processor: 16 cores or more with Intel® Virtualization Technology (Intel® VT)
+- Processor: 32 cores or more with Intel® Virtualization Technology (Intel® VT)
   for IA-32, Intel® 64 and Intel® Architecture (Intel® VT-x) and Intel®
   Virtualization Technology (Intel® VT) for Directed I/O (Intel® VT-d) support
   enabled in BIOS
 
-- Memory: 32 GB RAM or more
+- Memory: 64 GB RAM or more
 
 - Disk Space: 256 GB SSD or more
 


### PR DESCRIPTION
Reverts open-edge-platform/edge-manage-docs#53

These system requirements are incorrect.