### PR TITLE
[Documentation] Added Markdown in the lint checker

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,4 +8,4 @@ mitigation.
 
 Please report any security vulnerabilities in this project utilizing the
 guidelines
-[here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).
+[Intel Vulnerability Handling Guidelines](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ $(VENV_DIR): requirements.txt
 check: | $(VENV_DIR) ## Check for and/or install prerequisite tools
 
 # Eventually we want:
-# lint: license yamllint pylint black sphinx-spelling sphinx-linkcheck markdownlint ## Lint all tooling and docs
+# lint: license yamllint pylint black doc8 sphinx-spelling sphinx-linkcheck markdownlint ## Lint all tooling and docs
 
 # But for now, turn off format, spelling, link checks
-lint: license yamllint pylint black doc8 sphinx-spelling ## Lint all tooling
+lint: license yamllint pylint black doc8 sphinx-spelling markdownlint ## Lint all tooling
 
 license: $(VENV_DIR) ## license check with REUSE tool
 	set +u; . ./$</bin/activate; set -u ;\

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This repository contains documentation for the Edge Orchestrator.
 
 The repository root contains configuration and build tools; and the `docs/`
-directory contains the documentation text.
+the directory contains the documentation text.
 
 ## Create new content
 
@@ -31,7 +31,7 @@ Build the docs with `make` from the root directory:
   the output in the `out` directory.
 
 - `make lint` will check both documentation and supporting code.  This will
-  also be run in CI. You must run it before submitting code.
+  also be run in CI. You must run it before submitting the code.
 
 ## Documentation Conventions
 
@@ -76,7 +76,7 @@ sphinx-spelling`.
 If a valid human language word or phrase needs to be added, add it to
 `dict.txt` in alphabetical order.
 
-Sometimes words that include "curly" or "smart" quotes in contractions will be
+Sometimes, words that include "curly" or "smart" quotes in contractions will be
 marked as invalid - for example, if you get a spelling error for a word like
 `doesn`, delete the quote character and replace with a normal, non-curly quote.
 
@@ -109,6 +109,25 @@ Certain web servers will disallow linkcheck to access them, and return a `403`
 or similar errors. In this case, you may want to add the web address to the
 `linkcheck_ignore` list given in the `conf.py`.
 
+### Markdownlint
+
+To ensure the quality and consistency of our documentation, we include a markdown
+linter check as part of our continuous integration process. This step will help us
+automatically identify andcorrect common markdown issues, ensuring we adhere
+to best practices.
+
+Requirements
+
+Before running the markdown linting checks, make sure you have the following installed:
+
+- Node.js (version 12 or higher)
+- npm (Node package manager)
+- markdownlint-cli2
+
+You can install markdownlint-cli2 via npm with the following command:
+
+    npm install -g markdownlint-cli2
+
 ### References
 
 For references, avoid defining references manually because
@@ -128,9 +147,9 @@ ref you're looking for.
 You can find configuration across all Sphinx invocations under docconf.
 
 `docconf` is a Python module that is included in the virtualenv, so if you
-modify it, you must delete and recreate the virtualenv (`make clean-all` will
+modify it, you must delete and recreate the virtualenv `make clean-all` will
 delete, and targets that used the virtualenv will recreate it.
 
 ## License
 
-The Edge Orchestration documentation is licensed under [Apache 2.0][apache-license].
+The Edge Orchestration documentation is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/developer_guide/infra_manager/tutorials/upgrade/orch_upgrade.rst
+++ b/docs/developer_guide/infra_manager/tutorials/upgrade/orch_upgrade.rst
@@ -76,7 +76,7 @@ On the ``Host`` page of the Web UI, observe the status of the EN until it is ful
 Upgrade Infra Manager Version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To upgrade all Infrastructure Manager applications, log into your Edge Orchestrator and apply the following changes in the edge-managebility-framework repository cloned locally:
+To upgrade all Infrastructure Manager applications, log into your Edge Orchestrator and apply the following changes in the edge-manageability-framework repository cloned locally:
 
 1. Add infra-charts repo to ``githubRepos`` in ``mage/Magefile.go``:
 


### PR DESCRIPTION
# PR Description

The integration of a Markdown lint checker into the Makefile. This enhancement aims to ensure the consistency and quality of Markdown files throughout the project.

## Changes

- Addition of Markdown lint checker: The new lint checker will automatically verify the structure and syntax of Markdown files, identifying any issues and providing suggestions for fixes.
- Updates to Makefile: Minor modifications have been made to the Makefile to incorporate the lint checker functionality, ensuring it is executed as part of the regular build process.


## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
