### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ docs/developer_guide @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @
 README.md @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @Ram-srini @diwanc
 
 # CI files
-.github/ @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @Ram-srini @diwanc
+.github/ @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @Ram-srini @diwanc @jouillet
 
 # shared doc config
-docconf/ @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @Ram-srini @diwanc
+docconf/ @achamuah @soniabha-intc @scottmbaker @hyunsun @krishnajs @Ram-srini @diwanc @jouillet


### PR DESCRIPTION
I maintain the documentation GitHub workflows for OEP.  The `edge-manage-docs` docconf / workflow is used by the [shared publish-documentation workflow in orch-ci](https://github.com/open-edge-platform/orch-ci/blob/main/.github/workflows/publish-documentation.yml#L122). As such, I need to know whenever the docconf / workflow files change since it impacts *ALL* the OEP documentation.

# PR Description

Add `jouillet` as codeowner to `docconf` and `.github` to allow notifications on change.

## Changes

Add `jouillet` as codeowner to `docconf` and `.github`

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
