### PR TITLE
Update OXM profile and PXE provisioning docs for clarity

### DIFF
--- a/docs/deployment_guide/on_prem_deployment/on_prem_deployment_profiles/on_prem_oxm_profile.rst
+++ b/docs/deployment_guide/on_prem_deployment/on_prem_deployment_profiles/on_prem_oxm_profile.rst
@@ -1,3 +1,11 @@
+Introduction
+============
+
+The Edge Manageability Framework (EMF) serves a wide range of customers, including equipment manufacturers, system integrators, software vendors, and organizations managing edge deployments. To address scenarios where customers need to provision multiple edge nodes with both an operating system and Kubernetes, EMF offers support for the OXM profile.
+
+When operating in OXM profile mode, EMF acts as a dedicated provisioning solution stack—focusing exclusively on initial system deployment and intentionally omitting the activation of edge node agents for device lifecycle management. This approach provides a scalable provisioning solution, building upon the foundations of the `single standalone edge node <https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node>`_ deployment model.
+
+
 OXM Deployment Profile
 ======================
 

--- a/docs/user_guide/advanced_functionality/oxm_pxe_provisioning.rst
+++ b/docs/user_guide/advanced_functionality/oxm_pxe_provisioning.rst
@@ -1,12 +1,18 @@
-Provision Standalone Edge Nodes at scale
-========================================
+Provisioning Standalone Edge Nodes at Scale
+===========================================
 
-This guide assumes the use of the :doc:`OXM deployment profile of the on-premises Edge Orchestrator </deployment_guide/on_prem_deployment/on_prem_deployment_profiles/on_prem_oxm_profile>`.
+This guide provides step-by-step instructions for customers wishing to provision both the operating system and Kubernetes across multiple edge nodes simultaneously. This solution is particularly relevant for OEM vendor customers who require efficient and scalable deployment capabilities. To enable this use case, we utilize the OXM deployment profile within the on-premises Edge Orchestrator.
+
+When operating in OXM profile mode, the Edge Microvisor Framework (EMF) functions as a dedicated provisioning solution stack, focusing solely on initial system deployment and not enabling any edge node agents for device lifecycle management. This approach is designed specifically as a scalable provisioning solution, building upon the `single standalone edge node <https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node>`.
+
+Future releases will introduce the capability to add edge nodes to a complete device management EMF stack, allowing customers to leverage advanced lifecycle management features as their needs evolve.
+
+Refer to the :doc:`OXM deployment profile documentation </deployment_guide/on_prem_deployment/on_prem_deployment_profiles/on_prem_oxm_profile>` for background information.
 
 Set up environment
 ------------------
 
-#. Install Edge Orchestrator CLI. Please reach out to Intel to get access to the Edge Orchestrator CLI.
+#. Install Edge Orchestrator CLI (orch-cli) from Intel release service.
 
 #. Login to the Edge Orchestrator.
 


### PR DESCRIPTION
# PR Description

Added an introduction to the OXM profile documentation, clarifying its purpose and use cases. Expanded the PXE provisioning guide with more context on scalable deployments, clarified the role of EMF in OXM mode, and updated setup instructions for the Edge Orchestrator CLI.
This pull request updates the documentation to clarify the purpose and usage of the OXM deployment profile in the Edge Manageability Framework (EMF). It introduces new background content and improves the user guide to better explain how to provision multiple edge nodes at scale using the OXM profile. The changes are grouped into two main themes: documentation enhancements and user guide improvements.

Documentation enhancements:

* Added an "Introduction" section to `on_prem_oxm_profile.rst`, explaining the role of the OXM profile in EMF and its focus on scalable, initial provisioning of edge nodes without lifecycle management agents.


## Changes

User guide improvements:

* Expanded the introduction in `oxm_pxe_provisioning.rst` to clarify the use case for OEM customers, the scope of the OXM profile, and future plans for device lifecycle management integration.
* Updated setup instructions in `oxm_pxe_provisioning.rst` to specify installing the Edge Orchestrator CLI from the Intel release service, improving clarity for new users.


## Checklist

- [ ] Tests passed
- [x Documentation updated
