### PR TITLE
Clarify SSH key lifecycle management in docs

### DIFF
--- a/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
+++ b/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
@@ -62,5 +62,5 @@ Edge Manageability Framework allows you to add **public SSH keys** into a host d
       * **<key-name>** is the name provided when you add the SSH key.
       * **<host_ip_address>** is the IP address of the host. You can get the IP address through the **host** `View I/O Devices Details <./../set_up_edge_infra/provisioned_host_details.html#view-i-o-devices-details>`__ page of the web UI.
    
-   .. note::
+   .. warning::
       EMF does not support the lifecycle management (updating, deleting, rotate ssh keys) of the ssh keys installed on the edge node. If you need to rotate or remove the ssh keys, you will need to do it manually on the edge node before the key expires or is no longer needed. Same procedure can be followed to add more ssh keys to the edge node.

--- a/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
+++ b/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
@@ -61,6 +61,6 @@ Edge Manageability Framework allows you to add **public SSH keys** into a host d
    .. note::
       * **<key-name>** is the name provided when you add the SSH key.
       * **<host_ip_address>** is the IP address of the host. You can get the IP address through the **host** `View I/O Devices Details <./../set_up_edge_infra/provisioned_host_details.html#view-i-o-devices-details>`__ page of the web UI.
-   
+
    .. warning::
       EMF does not support the lifecycle management (updating, deleting, rotate ssh keys) of the ssh keys installed on the edge node. If you need to rotate or remove the ssh keys, you will need to do it manually on the edge node before the key expires or is no longer needed. Same procedure can be followed to add more ssh keys to the edge node.

--- a/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
+++ b/docs/user_guide/advanced_functionality/configure_ssh_public_keys.rst
@@ -61,3 +61,6 @@ Edge Manageability Framework allows you to add **public SSH keys** into a host d
    .. note::
       * **<key-name>** is the name provided when you add the SSH key.
       * **<host_ip_address>** is the IP address of the host. You can get the IP address through the **host** `View I/O Devices Details <./../set_up_edge_infra/provisioned_host_details.html#view-i-o-devices-details>`__ page of the web UI.
+   
+   .. note::
+      EMF does not support the lifecycle management (updating, deleting, rotate ssh keys) of the ssh keys installed on the edge node. If you need to rotate or remove the ssh keys, you will need to do it manually on the edge node before the key expires or is no longer needed. Same procedure can be followed to add more ssh keys to the edge node.


### PR DESCRIPTION
Added a note explaining that EMF does not support updating, deleting, or rotating SSH keys on edge nodes. Users must manage SSH keys manually for these operations.

# PR Description

This pull request adds an important clarification to the SSH key management documentation in the Edge Manageability Framework. The update makes it clear that lifecycle operations for SSH keys (such as updating, deleting, or rotating) are not supported by EMF and must be performed manually on the edge node.

Documentation update:

* Added a note explaining that EMF does not support lifecycle management (updating, deleting, rotating) of SSH keys on edge nodes, and that these actions must be performed manually. The note also clarifies that manual procedures should be followed for adding additional SSH keys.



## Checklist

- [x] Tests passed
- [x] Documentation updated
