### PR TITLE
Adjust branch_pattern filter

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -41,7 +41,7 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/publish-documentation.yml@a389c296f4a6dd2ff9d976007fd386950ab99605  # yamllint disable-line rule:line-length
     with:
       simple_mode: false
-      branch_pattern: '^(main|release-[0-9]+\.[0-9]+*)$'
+      branch_pattern: '^(main|release-[0-9]+\.[0-9]+.*)$'
     secrets:
       SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
       DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Same as #175, but for `post-merge` workflow.

Adjust `branch_pattern` filter to avoid [invalid regex](https://github.com/open-edge-platform/edge-manage-docs/actions/runs/17946672275/job/51034691727#step:8:103) on parsing branch names when executing the `Publish Documentation` workflow.

## Changes

`-      branch_pattern: '^(main|release-[0-9]+\.[0-9]+*)$'`
`+      branch_pattern: '^(main|release-[0-9]+\.[0-9]+.*)$'`


## Checklist

- [x] Tests passed
- [ ] Documentation updated

# PR Description

Describe the purpose of this pull request.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
