### PR TITLE
updating the cotainer img references to bitnamilegacy

### DIFF
--- a/docs/release_notes/3.1/containers_helm_charts_3.1.rst
+++ b/docs/release_notes/3.1/containers_helm_charts_3.1.rst
@@ -1585,15 +1585,15 @@ Docker Containers
    * - 2
      - kubectl
      - 1.28.4
-     - bitnami/kubectl:1.28.4
+     - bitnamilegacy/kubectl:1.28.4
    * - 3
      - kubectl
      - 1.31.3
-     - bitnami/kubectl:1.31.3
+     - bitnamilegacy/kubectl:1.31.3
    * - 4
      - kubectl
      - latest
-     - bitnami/kubectl
+     - bitnamilegacy/kubectl
    * - 5
      - busybox
      - 1.36.0

--- a/docs/release_notes/3.1/third_party_components_3.1.rst
+++ b/docs/release_notes/3.1/third_party_components_3.1.rst
@@ -357,11 +357,11 @@ Platform services
      - 24.0.1
    * - keycloak
      - image
-     - docker.io/bitnami/keycloak
+     - docker.io/bitnamilegacy/keycloak
      - 26.0.1-debian-12-r0
    * - keycloak (config-cli)
      - image
-     - docker.io/bitnami/keycloak-config-cli
+     - docker.io/bitnamilegacy/keycloak-config-cli
      - 6.1.6-debian-12-r4
    * - curl-jq
      - Container (utility)

--- a/docs/release_notes/3.1/third_party_components_3.1.rst
+++ b/docs/release_notes/3.1/third_party_components_3.1.rst
@@ -354,11 +354,11 @@ Platform services
    * - keycloak
      - helm chart
      - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-     - 24.0.1
+     - 24.4.12
    * - keycloak
      - image
      - docker.io/bitnamilegacy/keycloak
-     - 26.0.1-debian-12-r0
+     - 26.1.3-debian-12-r0
    * - keycloak (config-cli)
      - image
      - docker.io/bitnamilegacy/keycloak-config-cli

--- a/docs/release_notes/3.1/third_party_components_3.1.rst
+++ b/docs/release_notes/3.1/third_party_components_3.1.rst
@@ -37,7 +37,7 @@ Application Orchestration
      - v0.12.2
    * - redis (gitea)
      - Container
-     - docker.io/bitnami/redis
+     - docker.io/bitnamilegacy/redis
      - 7.2.5-debian-12-r4
    * - Harbor-core
      - Container
@@ -369,7 +369,7 @@ Platform services
      - sha256:fe8a5ee49f613495df3b57afa86b39f081bd1b3b9ed61248f46c3d3d7df56092
    * - kubectl
      - image
-     - bitnami/kubectl
+     - bitnamilegacy/kubectl
      - latest
    * - kiali
      - helm chart
@@ -417,7 +417,7 @@ Platform services
      - 15.5.26
    * - postgresql
      - image
-     - docker.io/bitnami/postgresql
+     - docker.io/bitnamilegacy/postgresql
      - 16.4.0-debian-12-r4
    * - reloader
      - helm chart
@@ -445,7 +445,7 @@ Platform services
      - 3.18.2
    * - vault (postgres dep)
      - image
-     - bitnami/postgresql
+     - bitnamilegacy/postgresql
      - 14.5.0-debian-11-r2
    * - vault
      - image
@@ -481,11 +481,11 @@ Platform services
      - 1.22.3-rootless
    * - gitea (postgres dep)
      - image
-     - docker.io/bitnami/postgresql
+     - docker.io/bitnamilegacy/postgresql
      - 16.3.1-debian-12-r23
    * - gitea (redis dep)
      - image
-     - docker.io/bitnami/redis
+     - docker.io/bitnamilegacy/redis
      - 7.2.5-debian-12-r4
 
 Observabilty (O11y)
@@ -741,7 +741,7 @@ User Interface
    * - bitnami/keycloak
      - Helm Chart
      - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-     - 24.0.1
+     - 24.4.12
    * - openpolicyagent/opa
      - ContainerImage
      - https://hub.docker.com/r/openpolicyagent/opa/


### PR DESCRIPTION
# PR Description

Updating release notes to reflect the updated container image repo (bitnami-> bitnamilegacy)

## Changes
Updated the container image's repo reff for the below mentioned artifacts, from bitnami to bitnamilegacy
- kubectl
- keycloak
- postgresql
- redis

## Checklist

- [x ] Tests passed
- [x ] Documentation updated
