### PR TITLE
Use `dev` instead of `main` when publishing

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -42,6 +42,7 @@ jobs:
     with:
       simple_mode: false
       branch_pattern: '^(main|release-[0-9]+\.[0-9]+.*)$'
+      switch_main_to_dev: true
     secrets:
       SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
       DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
# PR Description

Use `dev` instead of `main` when publishing

## Changes

Enable `switch_main_to_dev` in `post-merge` workflow.

## Checklist

- [x] Tests passed
- [ ] Documentation updated
