### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request makes a small configuration change to the Dependabot settings, introducing a cooldown period to limit how frequently pull requests are created.

* Added a `cooldown` setting with `default-days: 7` to the `.github/dependabot.yml` file, which will prevent Dependabot from opening new pull requests for the same dependency more than once every 7 days.