### PR TITLE
Clusters without CAPI

### DIFF
--- a/docs/user_guide/advanced_functionality/index.rst
+++ b/docs/user_guide/advanced_functionality/index.rst
@@ -41,3 +41,4 @@ application's capabilities:
    configure_edgenode_lvm_parition.rst
    custom_os_profile
    ubuntu_raw_image_generation_from_iso
+   provisioning_clusters_without_co

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -27,3 +27,6 @@ Cluster Provisioning
 
 Wait for the host to be provisioned and registered with EMF. Once the host is registered and onboarded to EMF,
 you can use the orch-cli to retrieve the host information and access the cluster configuration.
+
+The cluster configuration will be bundled with the host configuration,
+and you can retrieve it using the orch-cli commands to get the host details.

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -1,9 +1,9 @@
 Provisioning Clusters without Cluster Orchestrator (CO)
 =======================================================
 
-There could be various reasons for provisioning clusters without CO, such as testing, development,
-or specific use cases that do not require the full capabilities of CO. 
 This document describes how to provision clusters without using CO.
+There could be various reasons for provisioning clusters without CO, such as testing, development,
+or specific use cases that do not require the full capabilities of CO.
 The clusters provisioned using the methods described here will not be managed by CO,
 and thus will not be visible in the CO dashboard.
 However, their configuration will be bundled with their host configuration,
@@ -13,20 +13,34 @@ and retrievable using front end tools.
 Pre-requisites
 --------------
 - EMF installed and configured in the environment.
-- Access to the EMF API server.
+- Access to an EMF deployment.
 - Access to the Kubernetes\* cluster where EMF is installed.
 - orch-cli installed and configured to interact with the EMF API server (see :doc:`/user_guide/set_up_edge_infra/orch_cli/orch_cli_guide`)
 
 
 Cluster Provisioning
 --------------------
-1. Customize the cloud init file as explained here https://docs.openedgeplatform.intel.com/edge-manage-docs/2026.0/user_guide/advanced_functionality/oxm_pxe_provisioning.html#set-up-environment
+1. Customize the cloud init file as explained here `<https://docs.openedgeplatform.intel.com/edge-manage-docs/2026.0/user_guide/advanced_functionality/oxm_pxe_provisioning.html#set-up-environment>`_.
 2. Generate the stand alone configuration file
 3. Use orch-cli to create a host.
-
 
 Wait for the host to be provisioned and registered with EMF. Once the host is registered and onboarded to EMF,
 you can use the orch-cli to retrieve the host information and access the cluster configuration.
 
 The cluster configuration will be bundled with the host configuration,
 and you can retrieve it using the orch-cli commands to get the host details.
+
+If you try to generate the standalone configuration file using orch-cli and you get an error message
+similar to the one below:
+
+.. code-block:: shell
+  $ orch-cli generate standalone-config -c config-file -o cloud-init.cfg
+  Error: command "generate" is disabled in the current Edge Orchestrator configuration
+
+run the following command to enable the command in the Edge Orchestrator configuration:
+
+.. code-block:: shell
+  $ orch-cli config set orchestrator.features.edge-infrastructure-manager.oxm-profile.installed true
+
+The "generate" command should now be enabled, and you can proceed with generating
+the standalone configuration file and creating the host using the orch-cli.

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -1,0 +1,31 @@
+Provisioning Clusters without Cluster Orchestrator (CO)
+=======================================================
+
+
+The following sections describe how to provision clusters without using Edge Cluster Orchestrator.
+There could be various reasons for provisioning clusters without CO, such as testing, development,
+or specific use cases that do not require the full capabilities of CO.
+The methods described in this section allow you to provision clusters using EMF and orch-cli
+without the need for CO.
+The clusters provisioned using the methods described in this section will not be managed by CO,
+and thus will not be visible in the CO dashboard. However, their configuration will be bundled with
+their host configuration, and will be registered and managed by EMF.
+
+
+Pre-requisites
+-----------------
+- EMF installed and configured in the environment.
+- Access to the EMF API server.
+- Access to the Kubernetes\* cluster where EMF is installed.
+- orch-cli installed and configured to interact with the EMF API server (see :doc:`/user_guide/set_up_edge_infra/orch_cli/orch_cli_guide`)
+
+
+Cluster Provisioning
+--------------------
+1. Customize the cloud init file
+2. Generate the stand alone configuration file
+3. Use orch-cli to create a host.
+
+
+Wait for the host to be provisioned and registered with EMF. Once the host is registered and onboarded to EMF,
+you can use the orch-cli to retrieve the host information and access the cluster configuration.

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -36,7 +36,7 @@ similar to the one below:
 .. code-block:: shell
 
   $ orch-cli generate standalone-config -c config-file -o cloud-init.cfg
-  Error: command "generate" is disabled in the current Edge Orchestrator configuration
+  Error: command ``generate`` is disabled in the current Edge Orchestrator configuration
 
 run the following command to enable the command in the Edge Orchestrator configuration:
 
@@ -44,5 +44,5 @@ run the following command to enable the command in the Edge Orchestrator configu
 
   $ orch-cli config set orchestrator.features.edge-infrastructure-manager.oxm-profile.installed true
 
-The "generate" command should now be enabled, and you can proceed with generating
+The ``generate`` command should now be enabled, and you can proceed with generating
 the standalone configuration file and creating the host using the orch-cli.

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -1,19 +1,17 @@
 Provisioning Clusters without Cluster Orchestrator (CO)
 =======================================================
 
-
-The following sections describe how to provision clusters without using Edge Cluster Orchestrator.
 There could be various reasons for provisioning clusters without CO, such as testing, development,
-or specific use cases that do not require the full capabilities of CO.
-The methods described in this section allow you to provision clusters using EMF and orch-cli
-without the need for CO.
-The clusters provisioned using the methods described in this section will not be managed by CO,
-and thus will not be visible in the CO dashboard. However, their configuration will be bundled with
-their host configuration, and will be registered and managed by EMF.
+or specific use cases that do not require the full capabilities of CO. 
+This document describes how to provision clusters without using CO.
+The clusters provisioned using the methods described here will not be managed by CO,
+and thus will not be visible in the CO dashboard.
+However, their configuration will be bundled with their host configuration,
+and retrievable using front end tools.
 
 
 Pre-requisites
------------------
+--------------
 - EMF installed and configured in the environment.
 - Access to the EMF API server.
 - Access to the Kubernetes\* cluster where EMF is installed.

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -34,12 +34,14 @@ If you try to generate the standalone configuration file using orch-cli and you 
 similar to the one below:
 
 .. code-block:: shell
+
   $ orch-cli generate standalone-config -c config-file -o cloud-init.cfg
   Error: command "generate" is disabled in the current Edge Orchestrator configuration
 
 run the following command to enable the command in the Edge Orchestrator configuration:
 
 .. code-block:: shell
+
   $ orch-cli config set orchestrator.features.edge-infrastructure-manager.oxm-profile.installed true
 
 The "generate" command should now be enabled, and you can proceed with generating

--- a/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
+++ b/docs/user_guide/advanced_functionality/provisioning_clusters_without_co.rst
@@ -20,7 +20,7 @@ Pre-requisites
 
 Cluster Provisioning
 --------------------
-1. Customize the cloud init file
+1. Customize the cloud init file as explained here https://docs.openedgeplatform.intel.com/edge-manage-docs/2026.0/user_guide/advanced_functionality/oxm_pxe_provisioning.html#set-up-environment
 2. Generate the stand alone configuration file
 3. Use orch-cli to create a host.
 


### PR DESCRIPTION
# PR Description

Add clusters without CAPI framework document.

## Changes

Added new document to explain how do deploy an orchestrator without using CAPI framework

## Additional Information

n/a
## Checklist

- [x] Tests passed
- [x] Documentation updated
