### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -7,6 +7,8 @@ name: Post-Merge CI Pipeline
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ['main', 'release-*']
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the `Post-Merge CI Pipeline` GitHub Actions workflow. The pipeline will now also run when any tag is pushed, in addition to pushes to the `main` or `release-*` branches.