### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -7,8 +7,6 @@ name: Post-Merge CI Pipeline
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ['main', 'release-*']
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the post-merge CI pipeline configuration. It removes the triggering of the workflow on all tags, so the workflow will now only run on pushes to the `main` and `release-*` branches or when manually dispatched.

* Removed the `tags` trigger from the `push` event in `.github/workflows/post-merge.yml`, so the workflow no longer runs on tag pushes.